### PR TITLE
デプロイのワークフローを更新

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -3,23 +3,30 @@ name: GitHub Pages
 on:
   push:
     branches:
-      - master
+      - main
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
 
-      - name: Cache npm dependencies
-        uses: actions/cache@v2
+      - name: Get npm cache directory
+        id: npm-cache-dir
+        shell: bash
+        run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
+
+      - uses: actions/cache@v3
+        id: npm-cache # use this to check for `cache-hit` ==> if: steps.npm-cache.outputs.cache-hit != 'true'
         with:
-          path: ~/.npm
+          path: ${{ steps.npm-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
@@ -34,6 +41,7 @@ jobs:
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.ref == 'refs/heads/main' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -25,7 +25,7 @@ jobs:
           entrypoint: ./entrypoint.sh
 
       - run: npm ci
-      - run: npm run build:site
+      - run: npm run build:playground
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -17,19 +17,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '16'
-
-      - name: Get npm cache directory
-        id: npm-cache-dir
-        shell: bash
-        run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
-
-      - uses: actions/cache@v3
-        id: npm-cache # use this to check for `cache-hit` ==> if: steps.npm-cache.outputs.cache-hit != 'true'
-        with:
-          path: ${{ steps.npm-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          cache: 'npm'
 
       - name: Build WebAssembly
         uses: docker://terrorjack/asterius:201023

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "nazuki",
   "scripts": {
     "dev": "npm run dev --workspace=playground",
-    "build": "npm run build:wasm && npm run build:site",
+    "build": "npm run build:wasm && npm run build:playground",
     "build:wasm": "./build.sh --docker",
-    "build:site": "npm run build --workspace=playground"
+    "build:playground": "npm run build --workspace=playground"
   },
   "workspaces": [
     "playground"


### PR DESCRIPTION
いつの間にか `actions/setup-node` に `actions/cache` が組み込まれていて便利。