### PR TITLE
PR 作成時にデプロイワークフローが走らないようにする

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
実際にデプロイされるわけではないが、プルリクのたびに Docker イメージを落としたくないため。