### PR TITLE
ci: cache GHC binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,17 +31,13 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        ghc-version: [9.0.2]
-
     steps:
       - uses: actions/checkout@v3
 
       - uses: haskell/actions/setup@v2
         with:
-          ghc-version: ${{ matrix.ghc-version }}
           enable-stack: true
+          stack-no-global: true
 
       - uses: actions/cache@v3
         name: Cache ~/.stack
@@ -59,4 +55,4 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-stack-work-
 
-      - run: stack --system-ghc test
+      - run: stack test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   pull_request:
     paths:
+      - '.github/workflows/ci.yml'
       - 'app/**'
       - 'bench/**'
       - 'src/**'
@@ -16,6 +17,7 @@ on:
     branches:
       - main
     paths:
+      - '.github/workflows/ci.yml'
       - 'app/**'
       - 'bench/**'
       - 'src/**'


### PR DESCRIPTION
Resolves #44

CI 中で GHCup ではなく Stack を使って GHC をインストールすることで、キャッシュに残し、毎回 GHC をダウンロードしなくていいようにする